### PR TITLE
refactor: replace conditional logic in breakpoint handling with polymorphism

### DIFF
--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpointType.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpointType.java
@@ -76,28 +76,9 @@ public class CamelBreakpointType extends XLineBreakpointType<XBreakpointProperti
         final Document document = FileDocumentManager.getInstance().getDocument(file);
         final PsiFile psiFile = document != null ? PsiDocumentManager.getInstance(project).getPsiFile(document) : null;
 
-        switch (file.getFileType().getName()) {
-        case "XML":
-            XmlTag tag = IdeaUtils.getXmlTagAt(project, position);
-            if (tag == null) {
-                return false;
-            }
-            eipName = tag.getLocalName();
-            break;
-        case "JAVA":
-            PsiElement psiElement = XDebuggerUtil.getInstance().findContextElement(file, position.getOffset(), project, false);
-            if (psiElement == null) {
-                return false;
-            }
-            eipName = psiElement.getText();
-            break;
-        case "YAML":
-            YAMLKeyValue keyValue = IdeaUtils.getYamlKeyValueAt(project, position);
-            if (keyValue != null) {
-                eipName = keyValue.getKeyText();
-            }
-            break;
-        default: // noop
+        FileTypeHandler handler = FileTypeHandlerRegistry.getHandler(file.getFileType().getName());
+        if (handler != null) {
+            eipName = handler.getEipName(project, position, file);
         }
 
         try {

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/FileTypeHandler.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/FileTypeHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger.breakpoint;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.xdebugger.XSourcePosition;
+import org.jetbrains.annotations.Nullable;
+
+public interface FileTypeHandler {
+    @Nullable
+    String getEipName(Project project, XSourcePosition position, VirtualFile file);
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/FileTypeHandlerRegistry.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/FileTypeHandlerRegistry.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger.breakpoint;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class FileTypeHandlerRegistry {
+    private static final Map<String, FileTypeHandler> HANDLERS = new HashMap<>();
+
+    private FileTypeHandlerRegistry() {
+        // private constructor to hide the implicit public one
+    }
+
+    static {
+        HANDLERS.put("XML", new XmlFileHandler());
+        HANDLERS.put("JAVA", new JavaFileHandler());
+        HANDLERS.put("YAML", new YamlFileHandler());
+    }
+
+    public static FileTypeHandler getHandler(String fileTypeName) {
+        return HANDLERS.get(fileTypeName);
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/JavaFileHandler.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/JavaFileHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger.breakpoint;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.xdebugger.XDebuggerUtil;
+import com.intellij.xdebugger.XSourcePosition;
+import org.jetbrains.annotations.Nullable;
+
+public class JavaFileHandler implements FileTypeHandler {
+    @Override
+    public @Nullable String getEipName(Project project, XSourcePosition position, VirtualFile file) {
+        PsiElement psiElement = XDebuggerUtil.getInstance().findContextElement(file, position.getOffset(), project,
+                false);
+        return psiElement != null ? psiElement.getText() : null;
+    }
+}

--- a/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/YamlFileHandler.java
+++ b/src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/YamlFileHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.idea.runner.debugger.breakpoint;
+
+import com.github.cameltooling.idea.util.IdeaUtils;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.xdebugger.XSourcePosition;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.yaml.psi.YAMLKeyValue;
+
+public class YamlFileHandler implements FileTypeHandler {
+    @Override
+    public @Nullable String getEipName(Project project, XSourcePosition position, VirtualFile file) {
+        YAMLKeyValue keyValue = IdeaUtils.getYamlKeyValueAt(project, position);
+        return keyValue != null ? keyValue.getKeyText() : null;
+    }
+}


### PR DESCRIPTION
This pull request refactors the handling of file types in the `canPutAt` method of the `CamelBreakpointType` class by introducing a registry and handler pattern. This change aims to improve code maintainability and scalability.

Key changes include:

### Refactoring File Type Handling:

* [`src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/CamelBreakpointType.java`](diffhunk://#diff-9f97f84b0dcf340a2a547f95d0146cfb2ff14d88e3b3c730c42ea566a9891416L79-R81): Replaced the switch statement with a call to `FileTypeHandlerRegistry` to retrieve the appropriate `FileTypeHandler` and obtain the `eipName`.

* [`src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/FileTypeHandler.java`](diffhunk://#diff-964eb97166ec8a54fa52e88f05188e898591810511cfb122c230b97e75bd9490R1-R27): Introduced the `FileTypeHandler` interface with a method to get the EIP name based on the project, position, and file.

* [`src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/FileTypeHandlerRegistry.java`](diffhunk://#diff-a433b2fe85ad5465646a55ee5e7035e15c444cb08662ba87fd80872b3f03fa8fR1-R38): Added a registry class to manage different `FileTypeHandler` implementations for various file types.

* [`src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/JavaFileHandler.java`](diffhunk://#diff-2f088525bdea79aa3597ea1a6b8e998a08950caef230e637fa32223e0745441bR1-R33): Implemented the `FileTypeHandler` interface for handling Java files, extracting the EIP name from the PSI element.

* [`src/main/java/com/github/cameltooling/idea/runner/debugger/breakpoint/YamlFileHandler.java`](diffhunk://#diff-aa1d0e6ba2bf85d3a5958fed4dfe5d7a8e45b6e6471f32af011fb0df2d014ec6R1-R32): Implemented the `FileTypeHandler` interface for handling YAML files, extracting the EIP name from the YAML key value.